### PR TITLE
fix: preserve response body when retries exhausted with HTTP error 

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -100,7 +100,11 @@ func (c *Client) retryRoundTripper(next http.RoundTripper) http.RoundTripper {
 
 			// 如果是最后一次尝试，则不再重试，直接返回结果
 			if attempt >= c.retryOpts.MaxAttempts {
-				lastErr = ErrMaxRetriesExceeded
+				// 仅在无响应时设置 ErrMaxRetriesExceeded
+				// 有 HTTP 响应时保持 lastErr 为 nil，让下游 errorResponse() 正确构造包含响应体的 HTTPError
+				if resp == nil {
+					lastErr = ErrMaxRetriesExceeded
+				}
 				break
 			}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* 优化了 HTTP 请求重试失败时的错误处理，当最后一次尝试收到 HTTP 响应时，现在会显示实际的错误信息，而不是通用的重试上限错误提示，提高了故障排查的效率。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->