### PR TITLE
feat(httpc): implement RFC-aligned redirect following

### DIFF
--- a/client.go
+++ b/client.go
@@ -36,6 +36,8 @@ func New(opts ...Option) *Client {
 			Timeout: 0, // 默认 Client Timeout 为 0，表示不超时，由 Request Context 控制
 		},
 		//transport:     transport,
+		maxRedirects:  10,
+		followRedirect: true,
 		retryOpts:     defaultRetryOptions(),
 		randomFloat64: rand.Float64,
 		bufferPool:    newDefaultPool(defaultBufferSize),

--- a/errors.go
+++ b/errors.go
@@ -19,6 +19,7 @@ var (
 	ErrInvalidURL         = errors.New("httpc: invalid URL")
 	ErrInvalidSSEStream   = errors.New("httpc: invalid SSE stream")
 	ErrNoResponse         = errors.New("httpc: no response")
+	ErrUseLastResponse    = errors.New("httpc: use last response")
 )
 
 var ErrShortWrite = errors.New("short write")

--- a/httpc_test.go
+++ b/httpc_test.go
@@ -695,3 +695,114 @@ func TestRedirectCheckRedirectOverridesMaxRedirects(t *testing.T) {
 		t.Fatalf("error = %v, want custom limit reached", err)
 	}
 }
+
+func TestBodySlurpCopyNDoesNotBlockOnSmallChunkedBody(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	chunkedRedirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", target.URL)
+		w.WriteHeader(http.StatusFound)
+		_, _ = w.Write([]byte("small"))
+	}))
+	defer chunkedRedirector.Close()
+
+	done := make(chan struct{})
+	var resp *http.Response
+	var execErr error
+
+	go func() {
+		defer close(done)
+		resp, execErr = New(WithMaxRedirects(10)).GET(chunkedRedirector.URL).Execute()
+	}()
+
+	select {
+	case <-done:
+		if execErr != nil {
+			t.Fatalf("Execute() error = %v", execErr)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("body slurp blocked: io.CopyN did not return within timeout")
+	}
+}
+
+func TestBodySlurpCopyNDoesNotBlockOnEmptyChunkedBody(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	chunkedRedirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", target.URL)
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer chunkedRedirector.Close()
+
+	done := make(chan struct{})
+	var resp *http.Response
+	var execErr error
+
+	go func() {
+		defer close(done)
+		resp, execErr = New(WithMaxRedirects(10)).GET(chunkedRedirector.URL).Execute()
+	}()
+
+	select {
+	case <-done:
+		if execErr != nil {
+			t.Fatalf("Execute() error = %v", execErr)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("body slurp blocked: io.CopyN did not return within timeout")
+	}
+}
+
+func TestBodySlurpCopyNReadsAtMostMaxBodySlurpSize(t *testing.T) {
+	const maxBodySlurpSize = 2 << 10
+
+	largeBody := strings.Repeat("x", maxBodySlurpSize*4)
+
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", target.URL)
+		w.WriteHeader(http.StatusFound)
+		_, _ = w.Write([]byte(largeBody))
+	}))
+	defer redirector.Close()
+
+	done := make(chan struct{})
+	var resp *http.Response
+	var execErr error
+
+	go func() {
+		defer close(done)
+		resp, execErr = New(WithMaxRedirects(10)).GET(redirector.URL).Execute()
+	}()
+
+	select {
+	case <-done:
+		if execErr != nil {
+			t.Fatalf("Execute() error = %v", execErr)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("body slurp blocked on large body: io.CopyN did not return within timeout")
+	}
+}

--- a/httpc_test.go
+++ b/httpc_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -253,5 +254,316 @@ func TestCalculateExponentialBackoffWithJitterStillHonorsMaxDelay(t *testing.T) 
 	got := client.calculateExponentialBackoff(3, true)
 	if got != 800*time.Millisecond {
 		t.Fatalf("backoff with jitter cap = %v, want %v", got, 800*time.Millisecond)
+	}
+}
+
+func TestRedirect301PostSwitchesToGet(t *testing.T) {
+	var gotMethod atomic.Value
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod.Store(r.Method)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusMovedPermanently)
+	}))
+	defer redirector.Close()
+
+	resp, err := New().POST(redirector.URL).SetRawBody([]byte(`{"a":1}`)).Execute()
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if m, _ := gotMethod.Load().(string); m != http.MethodGet {
+		t.Fatalf("redirected method = %q, want GET", m)
+	}
+}
+
+func TestRedirect307PreservesMethodAndBody(t *testing.T) {
+	var gotMethod atomic.Value
+	var gotBody atomic.Value
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod.Store(r.Method)
+		b, _ := io.ReadAll(r.Body)
+		gotBody.Store(string(b))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", target.URL)
+		w.WriteHeader(http.StatusTemporaryRedirect)
+	}))
+	defer redirector.Close()
+
+	resp, err := New().POST(redirector.URL).SetRawBody([]byte(`payload`)).Execute()
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if m, _ := gotMethod.Load().(string); m != http.MethodPost {
+		t.Fatalf("redirected method = %q, want POST", m)
+	}
+	if b, _ := gotBody.Load().(string); b != "payload" {
+		t.Fatalf("redirected body = %q, want payload", b)
+	}
+}
+
+func TestRedirectFollowDisabledReturns3xx(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", target.URL)
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	resp, err := New(WithFollowRedirects(false)).GET(redirector.URL).Execute()
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("status = %d, want 302", resp.StatusCode)
+	}
+}
+
+func TestRedirectMaxRedirectsExceeded(t *testing.T) {
+	redirector := httptest.NewServer(nil)
+	redirector.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", redirector.URL)
+		w.WriteHeader(http.StatusFound)
+	})
+	defer redirector.Close()
+
+	_, err := New(WithMaxRedirects(2)).GET(redirector.URL).Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want redirect limit error")
+	}
+	if !strings.Contains(err.Error(), "stopped after 2 redirects") {
+		t.Fatalf("error = %v, want stopped after 2 redirects", err)
+	}
+}
+
+func TestRedirectStripsAuthorizationCrossDomain(t *testing.T) {
+	var authHeader atomic.Value
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader.Store(r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	u, err := url.Parse(target.URL)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", "http://"+u.Host+"/")
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	startURL := strings.Replace(redirector.URL, "127.0.0.1", "localhost", 1)
+
+	resp, err := New().GET(startURL).SetHeader("Authorization", "Bearer token").Execute()
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got, _ := authHeader.Load().(string); got != "" {
+		t.Fatalf("Authorization = %q, want empty", got)
+	}
+}
+
+func TestRedirect303ForcesGet(t *testing.T) {
+	var gotMethod atomic.Value
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod.Store(r.Method)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", target.URL)
+		w.WriteHeader(http.StatusSeeOther)
+	}))
+	defer redirector.Close()
+
+	resp, err := New().PUT(redirector.URL).SetRawBody([]byte("abc")).Execute()
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if m, _ := gotMethod.Load().(string); m != http.MethodGet {
+		t.Fatalf("redirected method = %q, want GET", m)
+	}
+}
+
+func TestRedirect308WithNonReplayableBodyReturns308(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", target.URL)
+		w.WriteHeader(http.StatusPermanentRedirect)
+	}))
+	defer redirector.Close()
+
+	body := io.NopCloser(strings.NewReader("stream-body"))
+	req, err := http.NewRequest(http.MethodPost, redirector.URL, body)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	req.GetBody = nil
+	req.ContentLength = int64(len("stream-body"))
+
+	resp, err := New().Do(req)
+	if err != nil {
+		t.Fatalf("Do() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusPermanentRedirect {
+		t.Fatalf("status = %d, want 308", resp.StatusCode)
+	}
+}
+
+func TestRedirectWithoutLocationReturnsOriginal3xx(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer server.Close()
+
+	resp, err := New().GET(server.URL).Execute()
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("status = %d, want 302", resp.StatusCode)
+	}
+}
+
+func TestRedirect302PostSwitchesToGet(t *testing.T) {
+	var gotMethod atomic.Value
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod.Store(r.Method)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	resp, err := New().POST(redirector.URL).SetRawBody([]byte(`{"a":1}`)).Execute()
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if m, _ := gotMethod.Load().(string); m != http.MethodGet {
+		t.Fatalf("redirected method = %q, want GET", m)
+	}
+}
+
+func TestRedirect308PreservesMethodAndBodyWhenReplayable(t *testing.T) {
+	var gotMethod atomic.Value
+	var gotBody atomic.Value
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod.Store(r.Method)
+		b, _ := io.ReadAll(r.Body)
+		gotBody.Store(string(b))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", target.URL)
+		w.WriteHeader(http.StatusPermanentRedirect)
+	}))
+	defer redirector.Close()
+
+	resp, err := New().POST(redirector.URL).SetRawBody([]byte("payload-308")).Execute()
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if m, _ := gotMethod.Load().(string); m != http.MethodPost {
+		t.Fatalf("redirected method = %q, want POST", m)
+	}
+	if b, _ := gotBody.Load().(string); b != "payload-308" {
+		t.Fatalf("redirected body = %q, want payload-308", b)
+	}
+}
+
+func TestRedirectRelativeLocationIsResolved(t *testing.T) {
+	var finalPath atomic.Value
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/start":
+			w.Header().Set("Location", "/final")
+			w.WriteHeader(http.StatusFound)
+		case "/final":
+			finalPath.Store(r.URL.Path)
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	resp, err := New().GET(server.URL + "/start").Execute()
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if p, _ := finalPath.Load().(string); p != "/final" {
+		t.Fatalf("final path = %q, want /final", p)
+	}
+}
+
+func TestRedirect307StripsAuthorizationCrossDomain(t *testing.T) {
+	var authHeader atomic.Value
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader.Store(r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	u, err := url.Parse(target.URL)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", "http://"+u.Host+"/")
+		w.WriteHeader(http.StatusTemporaryRedirect)
+	}))
+	defer redirector.Close()
+
+	startURL := strings.Replace(redirector.URL, "127.0.0.1", "localhost", 1)
+	resp, err := New().POST(startURL).SetRawBody([]byte("abc")).SetHeader("Authorization", "Bearer token").Execute()
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got, _ := authHeader.Load().(string); got != "" {
+		t.Fatalf("Authorization = %q, want empty", got)
 	}
 }

--- a/httpc_test.go
+++ b/httpc_test.go
@@ -2,6 +2,8 @@ package httpc
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -565,5 +567,131 @@ func TestRedirect307StripsAuthorizationCrossDomain(t *testing.T) {
 
 	if got, _ := authHeader.Load().(string); got != "" {
 		t.Fatalf("Authorization = %q, want empty", got)
+	}
+}
+
+func TestRedirectMaxRedirectsZeroReturns3xx(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", target.URL)
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	resp, err := New(WithMaxRedirects(0)).GET(redirector.URL).Execute()
+	if err != nil {
+		t.Fatalf("Execute() error = %v, want nil", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("status = %d, want 302", resp.StatusCode)
+	}
+}
+
+func TestRedirectMaxRedirectsNegativeReturns3xx(t *testing.T) {
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", "http://example.com")
+		w.WriteHeader(http.StatusMovedPermanently)
+	}))
+	defer redirector.Close()
+
+	resp, err := New(WithMaxRedirects(-5)).GET(redirector.URL).Execute()
+	if err != nil {
+		t.Fatalf("Execute() error = %v, want nil", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusMovedPermanently {
+		t.Fatalf("status = %d, want 301", resp.StatusCode)
+	}
+}
+
+func TestRedirectCheckRedirectUseLastResponse(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", target.URL)
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	client := New(WithCheckRedirect(func(req *http.Request, via []*http.Request) error {
+		return ErrUseLastResponse
+	}))
+
+	resp, err := client.GET(redirector.URL).Execute()
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("status = %d, want 302", resp.StatusCode)
+	}
+}
+
+func TestRedirectCheckRedirectCustomError(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", target.URL)
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	customErr := errors.New("custom redirect blocked")
+	client := New(WithCheckRedirect(func(req *http.Request, via []*http.Request) error {
+		return customErr
+	}))
+
+	_, err := client.GET(redirector.URL).Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want custom error")
+	}
+	if !strings.Contains(err.Error(), "custom redirect blocked") {
+		t.Fatalf("error = %v, want custom redirect blocked", err)
+	}
+}
+
+func TestRedirectCheckRedirectOverridesMaxRedirects(t *testing.T) {
+	var redirectCount atomic.Int32
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if redirectCount.Add(1) <= 5 {
+			w.Header().Set("Location", srv.URL)
+			w.WriteHeader(http.StatusFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := New(
+		WithMaxRedirects(1),
+		WithCheckRedirect(func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 3 {
+				return fmt.Errorf("custom limit reached")
+			}
+			return nil
+		}),
+	)
+
+	_, err := client.GET(srv.URL).Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want custom limit error")
+	}
+	if !strings.Contains(err.Error(), "custom limit reached") {
+		t.Fatalf("error = %v, want custom limit reached", err)
 	}
 }

--- a/options.go
+++ b/options.go
@@ -90,6 +90,30 @@ func WithTimeout(timeout time.Duration) Option {
 	}
 }
 
+// WithFollowRedirects 设置是否自动跟随重定向
+func WithFollowRedirects(follow bool) Option {
+	return func(c *Client) {
+		c.followRedirect = follow
+	}
+}
+
+// WithMaxRedirects 设置最大重定向次数
+func WithMaxRedirects(maxRedirects int) Option {
+	return func(c *Client) {
+		if maxRedirects < 0 {
+			maxRedirects = 0
+		}
+		c.maxRedirects = maxRedirects
+	}
+}
+
+// WithCheckRedirect 设置自定义重定向检查函数
+func WithCheckRedirect(fn func(req *http.Request, via []*http.Request) error) Option {
+	return func(c *Client) {
+		c.checkRedirect = fn
+	}
+}
+
 // WithDNSResolver 设置自定义DNS解析器
 // servers: 一个或多个DNS服务器地址, 格式为 "ip:port" (例如, "8.8.8.8:53")
 // timeout: DNS查询的超时时间如果为0, 将使用默认超时 (5秒)

--- a/options.go
+++ b/options.go
@@ -97,7 +97,10 @@ func WithFollowRedirects(follow bool) Option {
 	}
 }
 
-// WithMaxRedirects 设置最大重定向次数
+// WithMaxRedirects 设置最大重定向次数。
+// 0 表示禁止跟随重定向（直接返回 3xx 响应），负值等同于 0。
+// 默认值为 10，与 Go 标准库一致。
+// 若同时设置了 WithCheckRedirect，自定义函数将完全接管重定向策略，此设置失效。
 func WithMaxRedirects(maxRedirects int) Option {
 	return func(c *Client) {
 		if maxRedirects < 0 {
@@ -107,7 +110,12 @@ func WithMaxRedirects(maxRedirects int) Option {
 	}
 }
 
-// WithCheckRedirect 设置自定义重定向检查函数
+// WithCheckRedirect 设置自定义重定向检查函数。
+// 设置后将完全接管重定向策略，WithMaxRedirects 的默认限制失效。
+// 用户需在函数内自行实现重定向次数限制等逻辑。
+// 返回 ErrUseLastResponse 可阻止跟随并直接返回当前 3xx 响应。
+// 返回其他 error 将中止请求并返回该错误（响应 Body 已关闭）。
+// 返回 nil 则允许继续重定向。
 func WithCheckRedirect(fn func(req *http.Request, via []*http.Request) error) Option {
 	return func(c *Client) {
 		c.checkRedirect = fn

--- a/transport.go
+++ b/transport.go
@@ -146,8 +146,11 @@ func (c *Client) checkRedirectPolicy(req *http.Request, via []*http.Request) err
 	if c.checkRedirect != nil {
 		return c.checkRedirect(req, via)
 	}
+	if c.maxRedirects <= 0 {
+		return ErrUseLastResponse
+	}
 	if len(via) >= c.maxRedirects {
-		return fmt.Errorf("stopped after %d redirects", c.maxRedirects)
+		return fmt.Errorf("httpc: stopped after %d redirects", c.maxRedirects)
 	}
 	return nil
 }

--- a/transport.go
+++ b/transport.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -15,6 +16,13 @@ import (
 )
 
 func (c *Client) Do(req *http.Request) (*http.Response, error) {
+	if req == nil {
+		return nil, fmt.Errorf("httpc: nil request")
+	}
+	if req.URL == nil {
+		return nil, fmt.Errorf("httpc: nil request URL")
+	}
+
 	var finalRT http.RoundTripper = c.transport
 
 	// 逆序应用，使得第一个中间件在最外层
@@ -31,7 +39,185 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 		finalRT = c.retryRoundTripper(finalRT)
 	}
 
-	return finalRT.RoundTrip(req)
+	if !c.followRedirect {
+		return finalRT.RoundTrip(req)
+	}
+
+	var (
+		reqs                  []*http.Request
+		resp                  *http.Response
+		redirectMethod        string
+		includeBody           = true
+		stripSensitiveHeaders bool
+	)
+
+	copyHeaders := makeHeadersCopier(req)
+
+	for {
+		if len(reqs) > 0 {
+			loc := resp.Header.Get("Location")
+			if loc == "" {
+				return resp, nil
+			}
+
+			nextURL, err := req.URL.Parse(loc)
+			if err != nil {
+				resp.Body.Close()
+				return nil, err
+			}
+
+			host := ""
+			if req.Host != "" && req.Host != req.URL.Host {
+				if parsedLoc, _ := url.Parse(loc); parsedLoc != nil && !parsedLoc.IsAbs() {
+					host = req.Host
+				}
+			}
+
+			ireq := reqs[0]
+			req = &http.Request{
+				Method:   redirectMethod,
+				Response: resp,
+				URL:      nextURL,
+				Header:   make(http.Header),
+				Host:     host,
+			}
+			req = req.WithContext(ireq.Context())
+
+			if includeBody && ireq.GetBody != nil {
+				newBody, err := ireq.GetBody()
+				if err != nil {
+					resp.Body.Close()
+					return nil, err
+				}
+				req.Body = newBody
+				req.GetBody = ireq.GetBody
+				req.ContentLength = ireq.ContentLength
+			}
+
+			if !stripSensitiveHeaders && reqs[0].URL.Host != req.URL.Host {
+				if !shouldCopyHeaderOnRedirect(reqs[0].URL, req.URL) {
+					stripSensitiveHeaders = true
+				}
+			}
+
+			copyHeaders(req, stripSensitiveHeaders, !includeBody)
+			if ref := refererForURL(reqs[len(reqs)-1].URL, req.URL, req.Header.Get("Referer")); ref != "" {
+				req.Header.Set("Referer", ref)
+			}
+
+			if err := c.checkRedirectPolicy(req, reqs); err != nil {
+				if err == ErrUseLastResponse {
+					return resp, nil
+				}
+				resp.Body.Close()
+				return resp, err
+			}
+
+			const maxBodySlurpSize = 2 << 10
+			if resp.ContentLength == -1 || resp.ContentLength <= maxBodySlurpSize {
+				_, _ = io.CopyN(io.Discard, resp.Body, maxBodySlurpSize)
+			}
+			resp.Body.Close()
+		}
+
+		reqs = append(reqs, req)
+		var err error
+		resp, err = finalRT.RoundTrip(req)
+		if err != nil {
+			return nil, c.wrapError(err)
+		}
+
+		var shouldRedirect, includeBodyOnHop bool
+		redirectMethod, shouldRedirect, includeBodyOnHop = redirectBehavior(req.Method, resp, reqs[0])
+		if !shouldRedirect {
+			return resp, nil
+		}
+		if !includeBodyOnHop {
+			includeBody = false
+		}
+
+		if req.Body != nil {
+			req.Body.Close()
+		}
+	}
+}
+
+func (c *Client) checkRedirectPolicy(req *http.Request, via []*http.Request) error {
+	if c.checkRedirect != nil {
+		return c.checkRedirect(req, via)
+	}
+	if len(via) >= c.maxRedirects {
+		return fmt.Errorf("stopped after %d redirects", c.maxRedirects)
+	}
+	return nil
+}
+
+func redirectBehavior(reqMethod string, resp *http.Response, ireq *http.Request) (redirectMethod string, shouldRedirect, includeBody bool) {
+	switch resp.StatusCode {
+	case http.StatusMovedPermanently, http.StatusFound, http.StatusSeeOther:
+		redirectMethod = reqMethod
+		shouldRedirect = true
+		includeBody = false
+		if reqMethod != http.MethodGet && reqMethod != http.MethodHead {
+			redirectMethod = http.MethodGet
+		}
+	case http.StatusTemporaryRedirect, http.StatusPermanentRedirect:
+		redirectMethod = reqMethod
+		shouldRedirect = true
+		includeBody = true
+		if ireq.GetBody == nil && ireq.ContentLength != 0 {
+			shouldRedirect = false
+		}
+	}
+	return redirectMethod, shouldRedirect, includeBody
+}
+
+func makeHeadersCopier(ireq *http.Request) func(req *http.Request, stripSensitiveHeaders, stripBodyHeaders bool) {
+	ireqhdr := ireq.Header.Clone()
+	return func(req *http.Request, stripSensitiveHeaders, stripBodyHeaders bool) {
+		for k, vv := range ireqhdr {
+			sensitive := false
+			body := false
+			switch http.CanonicalHeaderKey(k) {
+			case "Authorization", "Www-Authenticate", "Cookie", "Cookie2", "Proxy-Authorization", "Proxy-Authenticate":
+				sensitive = true
+			case "Content-Encoding", "Content-Language", "Content-Location", "Content-Type":
+				body = true
+			}
+			if !(sensitive && stripSensitiveHeaders) && !(body && stripBodyHeaders) {
+				req.Header[k] = vv
+			}
+		}
+	}
+}
+
+func refererForURL(lastReq, newReq *url.URL, explicitRef string) string {
+	if explicitRef != "" {
+		return explicitRef
+	}
+	if lastReq.Scheme == "https" && newReq.Scheme == "http" {
+		return ""
+	}
+	req := *lastReq
+	req.User = nil
+	return req.String()
+}
+
+func shouldCopyHeaderOnRedirect(initial, dest *url.URL) bool {
+	return isDomainOrSubdomain(dest.Hostname(), initial.Hostname())
+}
+
+func isDomainOrSubdomain(sub, parent string) bool {
+	if sub == parent {
+		return true
+	}
+	if strings.ContainsAny(sub, ":%") {
+		return false
+	}
+	if !strings.HasSuffix(sub, parent) {
+		return false
+	}
+	return len(sub) > len(parent) && sub[len(sub)-len(parent)-1] == '.'
 }
 
 // logRoundTripper 是一个内部中间件，用于在请求发送前记录日志

--- a/types.go
+++ b/types.go
@@ -57,6 +57,9 @@ type DumpLogFunc func(ctx context.Context, log string)
 type Client struct {
 	client        *http.Client
 	transport     *http.Transport
+	checkRedirect func(req *http.Request, via []*http.Request) error
+	maxRedirects  int
+	followRedirect bool
 	retryOpts     RetryOptions
 	randomFloat64 func() float64
 	bufferPool    BufferPool


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加了完整的HTTP重定向处理支持，包括对多种HTTP状态码的正确处理
  * 新增配置选项用于控制重定向跟随、设置最大重定向次数和自定义重定向策略
  * 实现了跨域重定向时的安全头部处理和相对URL解析

* **测试**
  * 添加了重定向行为的全面测试覆盖

<!-- end of auto-generated comment: release notes by coderabbit.ai -->